### PR TITLE
Force content encoding to default

### DIFF
--- a/lib/paperclip/storage/database.rb
+++ b/lib/paperclip/storage/database.rb
@@ -181,7 +181,7 @@ module Paperclip
       end
 
       def file_contents(style = default_style)
-        file_for(style).file_contents
+        file_for(style).file_contents.force_encoding(Encoding.default_internal)
       end
 
       def flush_writes


### PR DESCRIPTION
The mysql2 gem will return columns w/o encoding (i.e. BLOB) as ASCII-8BIT.  Most current rails apps have a default encoding of UTF-8.  Forcing the encoding to match the default will prevent accidental transcoding errors if for some reason the file_contents try to get converted.
